### PR TITLE
feature/android-put-device-token

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -290,6 +290,10 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
     @ReactMethod
     fun getAnonymousId(promise: Promise) =
             promise.resolve(analytics.getAnalyticsContext().traits().anonymousId())
+    
+    @ReactMethod
+    fun putDeviceToken(token: String) =
+            analytics.getAnalyticsContext().putDeviceToken(token)
 }
 
 private fun optionsFrom(context: ReadableMap?, integrations: ReadableMap?): Options {


### PR DESCRIPTION
feat: add putDeviceToken reactMethod on android

Lifecycle events such as "Application Installed" and "Application Opened" do not have device tokens on Android.

This pr adds `putDeviceToken` on Android so that tokens can be added directly to Segment, so that Segment events will have a device token inside `context.device.token`.