### PR TITLE
feature/package-json-remove-main-field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@segment/analytics-react-native",
   "version": "1.4.9",
-  "main": "index.js",
   "license": "MIT",
   "workspaces": {
     "packages": [


### PR DESCRIPTION
feat: remove main field from package.json

![screen](https://user-images.githubusercontent.com/85192563/124163292-7427fc00-da6d-11eb-9f10-19475c8f11a5.png)

```
error: Error: While trying to resolve module `@segment/analytics-react-native` from file `/Users/glynthomas/pp/papa-app/src/utils/analytics/segment.ts`, the package `/Users/glynthomas/pp/papa-app/node_modules/@segment/analytics-react-native/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/glynthomas/pp/papa-app/node_modules/@segment/analytics-react-native/index.js`. Indeed, none of these files exist:
```